### PR TITLE
[BUGFIX] tiny typo is fixed in a method which processing metadata fields

### DIFF
--- a/Classes/Mapping/FalMapping.php
+++ b/Classes/Mapping/FalMapping.php
@@ -217,7 +217,7 @@ class FalMapping extends AbstractMapping
             if (isset($map[$propertyName])) {
                 $targetPropertyName = $map[$propertyName];
                 if (substr($targetPropertyName, 0, 9) === 'metadata.') {
-                    $metadata[substr($targetPropertyName, 9)] = $fieldValueReader->readResponseDataField($data['result'], $propertyName, $dimensionMapping);
+                    $metadata[substr($targetPropertyName, 9)] = $fieldValueReader->readResponseDataField($data['result'][0], $propertyName, $dimensionMapping);
                 }
             }
         }


### PR DESCRIPTION
This patch applies the following bugfix:

- tiny typo is fixed in a method which processing metadata fields. Without this fix we can not map any PIM File object properties and TYPO3 FAL metadata properties. Because $fieldValueReader->readResponseDataField method just returns always null.