### PR TITLE
fix: return one dimensional array of sql strings for TYPO3

### DIFF
--- a/Classes/DynamicModel/DynamicModelGenerator.php
+++ b/Classes/DynamicModel/DynamicModelGenerator.php
@@ -171,13 +171,11 @@ TEMPLATE;
         }
       }
     }
-    return [
-      array_merge(
-        $sqlString,
-        $schemaFromModules,
-        $staticSchemasFromExtensions
-      )
-    ];
+    return array_merge(
+      $sqlString,
+      $schemaFromModules,
+      $staticSchemasFromExtensions
+    );
   }
 
   /**


### PR DESCRIPTION
Refs: #26